### PR TITLE
Following blocks always takes 50% of the entire Advanced Column Block…

### DIFF
--- a/src/blocks/advance-columns/column/index.js
+++ b/src/blocks/advance-columns/column/index.js
@@ -37,7 +37,6 @@ registerBlockType("responsive-block-editor-addons/column", {
   attributes: {
     width: {
       type: "number",
-      default: 50,
     },
     topPadding: {
       type: "number",


### PR DESCRIPTION
… without considering a number of available columns.