### PR TITLE
TASK/WP-6726 and TASK/WP-6679

### DIFF
--- a/src/blocks/form/components/edit.js
+++ b/src/blocks/form/components/edit.js
@@ -81,6 +81,7 @@ export default class Edit extends Component {
     }
 
     return [
+      <style id={`responsive-block-editor-addons-form-style-${this.props.clientId}-inner`}>{EditorStyles(this.props)}</style>,
       <BlockControls key="controls">
       </BlockControls>,
       // Show the block controls on focus

--- a/src/blocks/form/input/components/edit.js
+++ b/src/blocks/form/input/components/edit.js
@@ -89,6 +89,7 @@ export default class Edit extends Component {
     }
 
     return [
+      <style id={`responsive-block-editor-addons-form-input-style-${this.props.clientId}-inner`}>{EditorStyles(this.props)}</style>,
       <BlockControls key="controls">
       </BlockControls>,
       // Show the block controls on focus

--- a/src/settings-components/TypographySettings/index.js
+++ b/src/settings-components/TypographySettings/index.js
@@ -22,6 +22,12 @@ const { SelectControl, RangeControl, PanelBody, Dashicon, TabPanel } = wp.compon
 const { Component, Fragment } = wp.element;
 import "./editor.scss";
 
+// Add the 'Default' option at the beginning of the font options
+const updatedFontOptions = [
+    { label: __("Default", "responsive-block-editor-addons"), value: 'Default' },
+    ...fontOptions,
+];
+
 const TypographyHelperControl = (props) => {
     const getAttrName = attrName => camelCase(sprintf(props.attrNameTemplate, attrName));
     var advancedControls;
@@ -158,7 +164,7 @@ class TypographyControl extends Component {
                     )}
                     <SelectControl
                         label={__("Font Family", "responsive-block-editor-addons")}
-                        options={fontOptions}
+                        options={updatedFontOptions}
                         value={this.props.values.family}
                         onChange={this.props.onChangeFontFamily}
                     />


### PR DESCRIPTION
TASK/WP-6726 - Add an option like 'Use Theme's Family' in RBA Blocks for the typography's Font Family setting.
TASK/WP-6679 - Bug in Responsive Block Editor Addons

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code