### PR TITLE
WP-7030 Fix warning on page header

### DIFF
--- a/src/blocks/form/attributes.js
+++ b/src/blocks/form/attributes.js
@@ -128,13 +128,8 @@ const attributes = {
     }
   },
   formButtonBorderRadius: {
-    type: "object",
-    default: {
-      top: '4px',
-      left: '4px',
-      right: '4px',
-      bottom: '4px',
-    }
+    type: "number",
+    default: 4,
   },
   formButtonTopRadius: {
     type: "number",
@@ -241,13 +236,8 @@ const attributes = {
     default: "",
   },
   formBorderRadius: {
-    type: "object",
-    default: {
-      top: '4px',
-      left: '4px',
-      right: '4px',
-      bottom: '4px',
-    }
+    type: "number",
+    default: 4,
   },
   formTopRadius: {
     type: "number",


### PR DESCRIPTION
Task ID: WP-7030
The formBorderRadius and formButtonBorderRadius
were passed as array from attributes.js in form
block which was giving warning, so changed that
value to number

## PR Request Template

### Common Checks
* [x] No PHPCS issues related to the files in the PR
* [x] Self-testing is done
* [x] Appropriate comments are added in the code
* [x] There are no error_log statements 
* [x] There are no unnecessary console log statements
* [x] Changelog is updated if required
* [x] Version no is updated if required
* [x] All best practices are followed, and code doesn't contain any deprecated code/methods
* [x] There are no console errors due to your code