### PR TITLE
WP-7077 Fix testimonial slider arrow button

### DIFF
--- a/src/blocks/post-carousel/components/edit.js
+++ b/src/blocks/post-carousel/components/edit.js
@@ -134,6 +134,8 @@ class LatestPostsBlock extends Component {
     };
 
     function NextArrow(props) {
+      const { onClick } = props;
+
       return (
         <button
           type="button"
@@ -142,6 +144,7 @@ class LatestPostsBlock extends Component {
           aria-label="Next"
           tabIndex="0"
           role="button"
+          onClick={ onClick }
         >
           <Dashicon
             icon="arrow-right-alt2"
@@ -154,6 +157,8 @@ class LatestPostsBlock extends Component {
     }
 
     function PrevArrow(props) {
+      const { onClick } = props;
+
       return (
         <button
           type="button"
@@ -162,6 +167,7 @@ class LatestPostsBlock extends Component {
           aria-label="Previous"
           tabIndex="0"
           role="button"
+          onClick={ onClick }
         >
           <Dashicon
             icon="arrow-left-alt2"
@@ -194,8 +200,8 @@ class LatestPostsBlock extends Component {
       dots: dots,
       rtl: false,
       draggable: false,
-      nextArrow: <NextArrow arrowSize={arrowSize} />,
-      prevArrow: <PrevArrow arrowSize={arrowSize} />,
+      nextArrow: <NextArrow arrowSize={arrowSize} onClick={() => this.next()}/>,
+      prevArrow: <PrevArrow arrowSize={arrowSize} onClick={() => this.previous()}/>,
       responsive: [
         {
           breakpoint: 976,

--- a/src/blocks/testimonial-slider/components/edit.js
+++ b/src/blocks/testimonial-slider/components/edit.js
@@ -793,6 +793,8 @@ class edit extends Component {
     ];
 
     function NextArrow(props) {
+      const { onClick } = props;
+
       return (
         <button
           type="button"
@@ -810,6 +812,7 @@ class edit extends Component {
               borderWidth: arrowBorderWidth,
               borderStyle: arrowBorderStyle,
           }}
+          onClick={ onClick }
         >
         { ResponsiveBlockEditorAddonsIcons.carousel_right }
         </button>
@@ -817,6 +820,8 @@ class edit extends Component {
     }
 
     function PrevArrow(props) {
+      const { onClick } = props;
+
       return (
         <button
           type="button"
@@ -834,6 +839,7 @@ class edit extends Component {
               borderWidth: arrowBorderWidth,
               borderStyle: arrowBorderStyle,
           }}
+          onClick={ onClick }
         >
         { ResponsiveBlockEditorAddonsIcons.carousel_left }
         </button>
@@ -857,8 +863,8 @@ class edit extends Component {
       dots: dots,
       rtl: false,
       draggable: false,
-      nextArrow: <NextArrow arrowSize={arrowSize} />,
-      prevArrow: <PrevArrow arrowSize={arrowSize} />,
+      nextArrow: <NextArrow arrowSize={arrowSize} onClick={() => this.next()}/>,
+      prevArrow: <PrevArrow arrowSize={arrowSize} onClick={() => this.previous()}/>,
       responsive: [
         {
           breakpoint: 1024,


### PR DESCRIPTION
Task ID: WP-7077
Fixed testimonial slider and post carousel arrow button functionality not working, by adding onclick event listener by using Slider functionality

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code