### PR TITLE
WP-6533 Fix count blocks animation on load

### DIFF
--- a/src/blocks/count-down/components/edit.js
+++ b/src/blocks/count-down/components/edit.js
@@ -49,6 +49,55 @@ class Edit extends Component {
 		 "responsive-block-editor-addons-count-down-style-" + this.props.clientId
 	   );
 	   document.head.appendChild($style);
+
+	   // Start the timer after block gets mounted
+	   this.startTimer();
+	 }
+
+	 startTimer() {
+	   const { clientId, setAttributes } = this.props;
+	   const { date } = this.props.attributes;
+
+	   let dateObj = new Date();
+	   dateObj.setDate(dateObj.getDate() + 30);
+	   if ( date ) {
+		dateObj = new Date( date );
+	   }
+
+		// ignore invalid date
+		if (!dateObj) return;
+		
+		let time = dateObj.getTime();
+  
+		const counter = () => {
+		  let now = new Date().getTime();
+		  let currentUtcOffset = moment(dateObj).utcOffset() * 60 * 1000;
+  
+		  let timer = new Date(time - now - currentUtcOffset);
+  
+		  if (time < now) {
+			setAttributes({ days: "0", hours: "0", minutes: "0", seconds: "0" });
+			return;
+		  }
+  
+		  // Calculate days, hours, minutes and seconds
+		  let oneDay = 24 * 60 * 60 * 1000; // hours * minutes * seconds * miliseconds
+		  let days = Math.floor((time - now) / oneDay).toString();
+		  let hours = timer.getHours().toString();
+		  let minutes = timer.getMinutes().toString();
+		  let seconds = timer.getSeconds().toString();
+  
+		  setAttributes({days, hours, minutes, seconds });
+		};
+  
+		// Clear interval if countdown already exists
+		if (window[clientId]) {
+		  clearInterval(window[clientId]);
+		}
+
+		if (clientId) {
+		  window[clientId] = setInterval(counter, 1000);
+		}
 	 }
 
 	render() {

--- a/src/blocks/count-down/components/inspector.js
+++ b/src/blocks/count-down/components/inspector.js
@@ -304,6 +304,7 @@ export default class Inspector extends Component {
     ];
 
     const onDateTimeChange = (momentObj) => {
+      const { block_id } = this.props.attributes;
       let date = momentObj._d;
 
       // ignore invalid date
@@ -333,12 +334,12 @@ export default class Inspector extends Component {
       };
 
       // Clear interval if countdown already exists
-      if (window[id]) {
-        clearInterval(window[id]);
+      if (window[block_id]) {
+        clearInterval(window[block_id]);
       }
 
-      if (id) {
-        window[id] = setInterval(counter, 1000);
+      if (block_id) {
+        window[block_id] = setInterval(counter, 1000);
       }
     };
 


### PR DESCRIPTION
The count down and count up block were not showing animation on first load, fixed this by adding the animation in edit.js also added the mutation observer for checking when the element is loaded in dom

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code