### PR TITLE
RBA-Review-UI Change border color of review notice

### DIFF
--- a/admin/css/responsive-block-editor-addons-admin.css
+++ b/admin/css/responsive-block-editor-addons-admin.css
@@ -77,11 +77,6 @@
     position: relative;
 }
 
-.rbea-ask-for-review-notice.rbea-notice-warning {
-    border-left-color: #00a32a;
-    border-left-width: 6px;
-}
-
 .rbea-ask-for-review-notice .rbea-notice-content-wrapper {
     display: flex;
     gap: 30px;

--- a/includes/class-responsive-block-editor-addons.php
+++ b/includes/class-responsive-block-editor-addons.php
@@ -1129,7 +1129,7 @@ class Responsive_Block_Editor_Addons {
 		} elseif ( false === (bool) get_transient( 'responsive_block_editor_addons_ask_review_flag' ) && false === get_option( 'responsive_block_editor_addons_review_notice_dismissed' ) ) {
 			$image_url = plugins_url( 'admin/images/responsive-blocks.svg', __DIR__ );
 			echo sprintf(
-				'<div class="notice rbea-notice-warning rbea-ask-for-review-notice">
+				'<div class="notice notice-info rbea-ask-for-review-notice">
 					<div class="rbea-notice-content-wrapper">
 						<div class="rbea-notice-image">
 							<img src="%8$s" class="custom-logo" alt="Responsive Blocks" itemprop="logo">


### PR DESCRIPTION
The review notice should have the color of admin notification color in the frontend previoulsy it was green which represented "success message" in admin panel, replaced it with blue which represent "information message".

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code