### PR TITLE
WP-6899 Fix Content Timeline invalid date issue

### DIFF
--- a/src/blocks/content-timeline/components/classes.js
+++ b/src/blocks/content-timeline/components/classes.js
@@ -7,7 +7,9 @@ function ContentTmClasses(attributes) {
   var arrow_align_class = "responsive-timeline__arrow-top" + " ";
   if (attributes.arrowlinAlignment == "center") {
     arrow_align_class = "responsive-timeline__arrow-center" + " ";
-  } else if (attributes.arrowlinAlignment == "bottom") {
+  } else if (attributes.arrowlinAlignment == "right") {
+    /* AlignmentToolbar take the value as {left, center, right} so we can not change that
+    but we need to get the arrow at bottom, so added this bottom class on matching with right*/
     arrow_align_class = "responsive-timeline__arrow-bottom" + " ";
   }
 

--- a/src/blocks/content-timeline/components/edit.js
+++ b/src/blocks/content-timeline/components/edit.js
@@ -267,11 +267,14 @@ export default class Edit extends Component {
                   }
 
                   var post_date = t_date[index].title;
-                  if ("custom" != dateFormat) {
+                  if ("custom" !== dateFormat) {
                     post_date = dateI18n(dateFormat, moment( t_date[index].title, 'MM/DD/YYYY' ).format("YYYY-MM-DD"));
                     if (post_date === "Invalid date") {
                       post_date = t_date[index].title;
                     }
+                  } else {
+                    post_date = t_date[index].title;
+                    isCenter = post_date;
                   }
 
                   return (

--- a/src/blocks/content-timeline/components/save.js
+++ b/src/blocks/content-timeline/components/save.js
@@ -92,11 +92,14 @@ export default class Save extends Component {
                   var icon_class =
                     "responsive-timeline__icon-new out-view-responsive-timeline__icon ";
                   var post_date = t_date[index].title;
-                  if ("custom" != dateFormat) {
+                  if ("custom" !== dateFormat) {
                     post_date = dateI18n(dateFormat, moment( t_date[index].title, 'DD/MM/YYYY' ).format("YYYY-MM-DD"));
                     if (post_date === "Invalid date") {
                       post_date = t_date[index].title;
                     }
+                  } else {
+                    post_date = t_date[index].title;
+                    isCenter = post_date;
                   }
                   return (
                     <article


### PR DESCRIPTION
Task ID: WP-6899
When Date format is set to "Normal Text", then on change of alignment it shows date as "invalid date". Fixed the issue by conditionally loading the date as simple text when "Normal Text" is selected.

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code